### PR TITLE
Issue#3 crud functionality

### DIFF
--- a/WorkFundamentals/Data/ApplicationDbContext.cs
+++ b/WorkFundamentals/Data/ApplicationDbContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using WorkFundamentals.Models;
 
 namespace WorkFundamentals.Data
 {
@@ -11,6 +12,37 @@ namespace WorkFundamentals.Data
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options)
         {
+        }
+
+        public DbSet<Employee> Employees { get; set; }
+        public DbSet<Manager> Managers { get; set; }
+        public DbSet<Schedule> Schedules { get; set; }
+        public DbSet<WorkTask> WorkTasks { get; set; }
+        public DbSet<WorkTaskCategory> WorkTaskCategories { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<WorkTask>() //Dependent entity
+                        .HasOne<Employee>() //Parent Entity
+                        .WithMany()
+                        .HasForeignKey(wt => wt.EmployeeId);
+
+            modelBuilder.Entity<Schedule>() //Dependent entity
+                        .HasOne<Employee>() //Parent Entity
+                        .WithMany()
+                        .HasForeignKey(sc => sc.EmployeeId);
+
+            modelBuilder.Entity<WorkTaskCategory>() //Dependent entity
+                        .HasOne<WorkTask>() //Parent Entity
+                        .WithMany()
+                        .HasForeignKey(wtc => wtc.WorkTaskId);
+
+            modelBuilder.Entity<Schedule>() //Dependent entity
+                        .HasOne<WorkTask>() //Parent Entity
+                        .WithMany()
+                        .HasForeignKey(sc => sc.WorkTaskId);
         }
     }
 }

--- a/WorkFundamentals/Data/DbHelpers/EmployeeDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/EmployeeDb.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WorkFundamentals.Models;
+
+namespace WorkFundamentals.Data
+{
+    public class EmployeeDb
+    {
+        public async Task<List<Employee>> GetAllEmployees(ApplicationDbContext context)
+        {
+            List<Employee> employees =  await context.Employees
+                .OrderBy(e => e.Name)
+                .ToListAsync();
+
+            return employees;
+        }
+
+        public async Task<Employee> GetEmployeeById(int id, ApplicationDbContext context)
+        {
+            Employee employee = await context.Employees
+                .Where(e => e.EmployeeId == id)
+                .SingleOrDefaultAsync();
+
+            return employee;
+        }
+
+        public async void Add(Employee employee, ApplicationDbContext context)
+        {
+            await context.Employees.AddAsync(employee);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task<Employee> Update(Employee employee, ApplicationDbContext context)
+        {
+            context.Employees.Attach(employee);
+            context.Entry(employee).State = EntityState.Modified;
+            await context.SaveChangesAsync();
+
+            return employee;
+        }
+
+        public async void Delete(Employee employee, ApplicationDbContext context)
+        {
+            context.Employees.Attach(employee);
+            context.Entry(employee).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/WorkFundamentals/Data/DbHelpers/ManagerDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/ManagerDb.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WorkFundamentals.Models;
+
+namespace WorkFundamentals.Data.DbHelpers
+{
+    public class ManagerDb
+    {
+        public async Task<List<Manager>> GetAllEmployees(ApplicationDbContext context)
+        {
+            List<Manager> managers = await context.Managers
+                .OrderBy(m => m.Name)
+                .ToListAsync();
+
+            return managers;
+        }
+
+        public async Task<Manager> GetEmployeeById(int id, ApplicationDbContext context)
+        {
+            Manager managers = await context.Managers
+                .Where(m => m.ManagerId == id)
+                .SingleOrDefaultAsync();
+
+            return managers;
+        }
+
+        public async void Add(Manager manager, ApplicationDbContext context)
+        {
+            await context.Managers.AddAsync(manager);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task<Manager> Update(Manager manager, ApplicationDbContext context)
+        {
+            context.Managers.Attach(manager);
+            context.Entry(manager).State = EntityState.Modified;
+            await context.SaveChangesAsync();
+
+            return manager;
+        }
+
+        public async void Delete(Manager manager, ApplicationDbContext context)
+        {
+            context.Managers.Attach(manager);
+            context.Entry(manager).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/WorkFundamentals/Data/DbHelpers/ManagerDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/ManagerDb.cs
@@ -9,7 +9,7 @@ namespace WorkFundamentals.Data.DbHelpers
 {
     public class ManagerDb
     {
-        public async Task<List<Manager>> GetAllEmployees(ApplicationDbContext context)
+        public async Task<List<Manager>> GetAllManagers(ApplicationDbContext context)
         {
             List<Manager> managers = await context.Managers
                 .OrderBy(m => m.Name)
@@ -18,7 +18,7 @@ namespace WorkFundamentals.Data.DbHelpers
             return managers;
         }
 
-        public async Task<Manager> GetEmployeeById(int id, ApplicationDbContext context)
+        public async Task<Manager> GetManagerById(int id, ApplicationDbContext context)
         {
             Manager managers = await context.Managers
                 .Where(m => m.ManagerId == id)

--- a/WorkFundamentals/Data/DbHelpers/ScheduleDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/ScheduleDb.cs
@@ -18,6 +18,25 @@ namespace WorkFundamentals.Data.DbHelpers
             return schedules;
         }
 
+        public async Task<Schedule> GetCurrentScheduleByEmployeeId(int id, ApplicationDbContext context)
+        {
+            Schedule schedule = await context.Schedules
+                .Where(s => s.EmployeeId == id)
+                .Where(s => s.IsCurrent)
+                .SingleOrDefaultAsync();
+
+            return schedule;
+        }
+
+        public async Task<Schedule> GetScheduleByWorkTaskId(int id, ApplicationDbContext context)
+        {
+            Schedule schedule = await context.Schedules
+                .Where(s => s.WorkTaskId == id)
+                .SingleOrDefaultAsync();
+
+            return schedule;
+        }
+
         public async Task<Schedule> GetScheduleById(int id, ApplicationDbContext context)
         {
             Schedule schedules = await context.Schedules

--- a/WorkFundamentals/Data/DbHelpers/ScheduleDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/ScheduleDb.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WorkFundamentals.Models;
+
+namespace WorkFundamentals.Data.DbHelpers
+{
+    public class ScheduleDb
+    {
+        public async Task<List<Schedule>> GetAllSchedules(ApplicationDbContext context)
+        {
+            List<Schedule> schedules = await context.Schedules
+                .OrderByDescending(s => s.StartingDate)
+                .ToListAsync();
+
+            return schedules;
+        }
+
+        public async Task<Schedule> GetScheduleById(int id, ApplicationDbContext context)
+        {
+            Schedule schedules = await context.Schedules
+                .Where(s => s.ScheduleId == id)
+                .SingleOrDefaultAsync();
+
+            return schedules;
+        }
+
+        public async void Add(Schedule schedule, ApplicationDbContext context)
+        {
+            await context.Schedules.AddAsync(schedule);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task<Schedule> Update(Schedule schedule, ApplicationDbContext context)
+        {
+            context.Schedules.Attach(schedule);
+            context.Entry(schedule).State = EntityState.Modified;
+            await context.SaveChangesAsync();
+
+            return schedule;
+        }
+
+        public async void Delete(Schedule schedule, ApplicationDbContext context)
+        {
+            context.Schedules.Attach(schedule);
+            context.Entry(schedule).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/WorkFundamentals/Data/DbHelpers/WorkTaskDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/WorkTaskDb.cs
@@ -17,6 +17,14 @@ namespace WorkFundamentals.Data.DbHelpers
 
             return workTasks;
         }
+        public async Task<List<WorkTask>> GetAllWorkTasksByEmployeeId(int id, ApplicationDbContext context)
+        {
+            List<WorkTask> workTasks = await context.WorkTasks
+                .Where(wt => wt.EmployeeId == id)
+                .ToListAsync();
+
+            return workTasks;
+        }
 
         public async Task<WorkTask> GetWorkTaskById(int id, ApplicationDbContext context)
         {
@@ -26,6 +34,16 @@ namespace WorkFundamentals.Data.DbHelpers
 
             return workTasks;
         }
+
+        public async Task<WorkTaskCategory> GetCategoryByWorkTaskId(int id, ApplicationDbContext context)
+        {
+            WorkTaskCategory category = await context.WorkTaskCategories
+                .Where(wtc => wtc.WorkTaskId == id)
+                .SingleOrDefaultAsync();
+
+            return category;
+        }
+
 
         public async void Add(WorkTask workTask, ApplicationDbContext context)
         {

--- a/WorkFundamentals/Data/DbHelpers/WorkTaskDb.cs
+++ b/WorkFundamentals/Data/DbHelpers/WorkTaskDb.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WorkFundamentals.Models;
+
+namespace WorkFundamentals.Data.DbHelpers
+{
+    public class WorkTaskDb
+    {
+        public async Task<List<WorkTask>> GetAllWorkTasks(ApplicationDbContext context)
+        {
+            List<WorkTask> workTasks = await context.WorkTasks
+                .OrderBy(wt => wt.Title)
+                .ToListAsync();
+
+            return workTasks;
+        }
+
+        public async Task<WorkTask> GetWorkTaskById(int id, ApplicationDbContext context)
+        {
+            WorkTask workTasks = await context.WorkTasks
+                .Where(wt => wt.WorkTaskId == id)
+                .SingleOrDefaultAsync();
+
+            return workTasks;
+        }
+
+        public async void Add(WorkTask workTask, ApplicationDbContext context)
+        {
+            await context.WorkTasks.AddAsync(workTask);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task<WorkTask> Update(WorkTask workTask, ApplicationDbContext context)
+        {
+            context.WorkTasks.Attach(workTask);
+            context.Entry(workTask).State = EntityState.Modified;
+            await context.SaveChangesAsync();
+
+            return workTask;
+        }
+
+        public async void Delete(WorkTask workTask, ApplicationDbContext context)
+        {
+            context.WorkTasks.Attach(workTask);
+            context.Entry(workTask).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/WorkFundamentals/Data/Migrations/20200730220047_InitialMigration.Designer.cs
+++ b/WorkFundamentals/Data/Migrations/20200730220047_InitialMigration.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WorkFundamentals.Data;
 
 namespace WorkFundamentals.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200730220047_InitialMigration")]
+    partial class InitialMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WorkFundamentals/Data/Migrations/20200730220047_InitialMigration.cs
+++ b/WorkFundamentals/Data/Migrations/20200730220047_InitialMigration.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WorkFundamentals.Data.Migrations
+{
+    public partial class InitialMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Employees",
+                columns: table => new
+                {
+                    EmployeeId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(nullable: true),
+                    JobTitle = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Employees", x => x.EmployeeId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Managers",
+                columns: table => new
+                {
+                    ManagerId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(nullable: true),
+                    JobTitle = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Managers", x => x.ManagerId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkTasks",
+                columns: table => new
+                {
+                    WorkTaskId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    EmployeeId = table.Column<int>(nullable: false),
+                    Title = table.Column<string>(nullable: true),
+                    Description = table.Column<string>(nullable: true),
+                    IsComplete = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkTasks", x => x.WorkTaskId);
+                    table.ForeignKey(
+                        name: "FK_WorkTasks_Employees_EmployeeId",
+                        column: x => x.EmployeeId,
+                        principalTable: "Employees",
+                        principalColumn: "EmployeeId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Schedules",
+                columns: table => new
+                {
+                    ScheduleId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    EmployeeId = table.Column<int>(nullable: false),
+                    WorkTaskId = table.Column<int>(nullable: true),
+                    IsCurrent = table.Column<bool>(nullable: false),
+                    StartingDate = table.Column<DateTime>(nullable: false),
+                    DailyScheduleAsJSON = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Schedules", x => x.ScheduleId);
+                    table.ForeignKey(
+                        name: "FK_Schedules_Employees_EmployeeId",
+                        column: x => x.EmployeeId,
+                        principalTable: "Employees",
+                        principalColumn: "EmployeeId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Schedules_WorkTasks_WorkTaskId",
+                        column: x => x.WorkTaskId,
+                        principalTable: "WorkTasks",
+                        principalColumn: "WorkTaskId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkTaskCategories",
+                columns: table => new
+                {
+                    WorkTaskCategoryId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    WorkTaskId = table.Column<int>(nullable: false),
+                    Title = table.Column<string>(nullable: true),
+                    Description = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkTaskCategories", x => x.WorkTaskCategoryId);
+                    table.ForeignKey(
+                        name: "FK_WorkTaskCategories_WorkTasks_WorkTaskId",
+                        column: x => x.WorkTaskId,
+                        principalTable: "WorkTasks",
+                        principalColumn: "WorkTaskId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schedules_EmployeeId",
+                table: "Schedules",
+                column: "EmployeeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schedules_WorkTaskId",
+                table: "Schedules",
+                column: "WorkTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkTaskCategories_WorkTaskId",
+                table: "WorkTaskCategories",
+                column: "WorkTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkTasks_EmployeeId",
+                table: "WorkTasks",
+                column: "EmployeeId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Managers");
+
+            migrationBuilder.DropTable(
+                name: "Schedules");
+
+            migrationBuilder.DropTable(
+                name: "WorkTaskCategories");
+
+            migrationBuilder.DropTable(
+                name: "WorkTasks");
+
+            migrationBuilder.DropTable(
+                name: "Employees");
+        }
+    }
+}

--- a/WorkFundamentals/Models/Employee.cs
+++ b/WorkFundamentals/Models/Employee.cs
@@ -12,16 +12,10 @@ namespace WorkFundamentals.Models
     public class Employee
     {
         [Key]
-        public int Id { get; set; }
+        public int EmployeeId { get; set; }
 
         public string Name { get; set; }
 
         public string JobTitle { get; set; }
-
-        public Schedule CurrentSchedule { get; set; }
-
-        public List<WorkTask> CurrentTasks { get; set; }
-
-        public List<WorkTask> CompletedTasks { get; set; }
     }
 }

--- a/WorkFundamentals/Models/Manager.cs
+++ b/WorkFundamentals/Models/Manager.cs
@@ -12,7 +12,7 @@ namespace WorkFundamentals.Models
     public class Manager
     {
         [Key]
-        public int Id { get; set; }
+        public int ManagerId { get; set; }
 
         public string Name { get; set; }
 

--- a/WorkFundamentals/Models/Schedule.cs
+++ b/WorkFundamentals/Models/Schedule.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -32,7 +35,21 @@ namespace WorkFundamentals.Models
 
         public DateTime StartingDate { get; set; }
 
+        [NotMapped]
         public Dictionary<Day, DateTime> DailySchedule { get; set; }
+
+        public string DailyScheduleAsJSON
+        {
+            get
+            {
+                return JsonConvert.SerializeObject(DailySchedule, Formatting.Indented);
+            }
+            set 
+            {
+                JsonConvert.DeserializeObject<Dictionary<Day, DateTime>>(value);
+            }
+        }
+
 
         public Schedule()
         {

--- a/WorkFundamentals/Models/Schedule.cs
+++ b/WorkFundamentals/Models/Schedule.cs
@@ -13,12 +13,17 @@ namespace WorkFundamentals.Models
     public class Schedule
     {
         [Key]
-        public int Id { get; set; }
+        public int ScheduleId { get; set; }
 
         /// <summary>
-        /// The Employee the schedule belongs to
+        /// Foreign Key for Employee
         /// </summary>
-        public Employee Employee { get; set; }
+        public int EmployeeId { get; set; }
+
+        /// <summary>
+        /// Foreign Key for WorkTask
+        /// </summary>
+        public int? WorkTaskId { get; set; }
 
         /// <summary>
         /// Indicates whether the Schedule is for the current week or not.

--- a/WorkFundamentals/Models/WorkTask.cs
+++ b/WorkFundamentals/Models/WorkTask.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.SignalR;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -10,17 +12,20 @@ namespace WorkFundamentals.Models
     /// </summary>
     public class WorkTask
     {
-        public int Id { get; set; }
+        [Key]
+        public int WorkTaskId { get; set; }
+
+        /// <summary>
+        /// Foreign Key for Employee
+        /// </summary>
+        [Required]
+        public int EmployeeId { get; set; }
 
         public string Title { get; set; }
 
         public string Description { get; set; }
 
-        public Employee Employee { get; set; }
-
-        public Schedule Schedule { get; set; }
-
-        public WorkTaskCategory Category { get; set; }
+        public Boolean IsComplete { get; set; }
     }
 
     /// <summary>
@@ -28,6 +33,14 @@ namespace WorkFundamentals.Models
     /// </summary>
     public class WorkTaskCategory
     {
+        [Key]
+        public int WorkTaskCategoryId { get; set; }
+
+        /// <summary>
+        /// Foreign Key for WorkTask
+        /// </summary>
+        public int WorkTaskId { get; set; }
+
         public string Title { get; set; }
 
         public string Description { get; set; }

--- a/WorkFundamentals/appsettings.json
+++ b/WorkFundamentals/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-WorkFundamentals-7A26BA96-7595-4955-85FA-95E5D4DCE47D;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=WorkFundamentals;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Closes #3 
Created all Db Helper classes with CRUD functionality and set up the relationships in ApplicationDbContext, then created the initial migration files. The Schedule class has a Dictionary property, which isn't compatible with the database, so I created a separate property that Serializes  the Dictionary property for the database. 